### PR TITLE
プロテイン摂取履歴を削除時に摂取カウントを加算する

### DIFF
--- a/src/component/inputForm.tsx
+++ b/src/component/inputForm.tsx
@@ -3,8 +3,6 @@ import {
   Input,
   VStack,
   HStack,
-  Box,
-  Flex,
   Text,
   FormControl,
   NumberInput,
@@ -16,7 +14,6 @@ import {
 import { useState, useContext } from 'react';
 import { CountUpProps } from 'react-countup';
 import RegisterButton from './uiParts/registerButton';
-import useProteinCount from '../logic/proteinCount';
 import { InputContext } from '../page/mainFunction';
 
 interface FormProps {
@@ -35,10 +32,7 @@ export default function InputForm({ initialValue, onChange, end, ...options }: C
   const [gram, setGram] = useState<number>(initialValue);
   const [invalidFlg, setInvalidFlg] = useState<boolean>(false);
   const { inputValues, gramTotal, setInputValues, setGramTotal } = useContext(InputContext);
-  const { countUpRef, update } = useProteinCount({
-    end: gramTotal,
-    ...options,
-  });
+
   const handleSubmit = (): void => {
     if (name === '' || gram === 0) {
       setInvalidFlg(true);
@@ -52,7 +46,6 @@ export default function InputForm({ initialValue, onChange, end, ...options }: C
       },
     ];
     const result: number = gramTotal - gram;
-    update(result);
     setGramTotal(result);
     setInputValues(newInputValues);
     localStorage.setItem('inputHistory', JSON.stringify(newInputValues));
@@ -71,12 +64,6 @@ export default function InputForm({ initialValue, onChange, end, ...options }: C
 
   return (
     <VStack>
-      <Flex justifyContent={'center'} alignItems={'center'}>
-        <Box fontSize={100} pr={3} ref={countUpRef} />
-        <Text fontSize={60} pt={2}>
-          g
-        </Text>
-      </Flex>
       <HStack alignItems={'end'} mb={10}>
         <FormControl>
           <FormLabel htmlFor='name'>食品名</FormLabel>

--- a/src/component/inputHistory.tsx
+++ b/src/component/inputHistory.tsx
@@ -3,12 +3,15 @@ import { useContext } from 'react';
 import { InputContext } from '../page/mainFunction';
 
 export default function InputHistory() {
-  const { inputValues, setInputValues } = useContext(InputContext);
+  const { inputValues, gramTotal, setInputValues, setGramTotal } = useContext(InputContext);
 
   const handleDelete = (index: number) => {
     const newInputValues = [...inputValues];
     newInputValues.splice(index, 1);
     setInputValues(newInputValues);
+    const result: number = gramTotal + inputValues[0].gram;
+    setGramTotal(result);
+    localStorage.setItem('gramTotal', result.toString());
     localStorage.setItem('inputHistory', JSON.stringify(newInputValues));
   };
 

--- a/src/page/mainFunction.tsx
+++ b/src/page/mainFunction.tsx
@@ -1,13 +1,19 @@
-import { VStack, Heading } from '@chakra-ui/react';
+import { VStack, Heading, Box, Flex, Text } from '@chakra-ui/react';
 import { useState, useEffect, createContext } from 'react';
+import { CountUpProps } from 'react-countup';
 import CountDown from '../component/countDown';
 import InputForm from '../component/inputForm';
 import InputHistory from '../component/inputHistory';
 import ProteinMeter from '../component/proteinMeter';
+import useProteinCount from '../logic/proteinCount';
 
 interface InputProps {
   name: string;
   gram: number;
+}
+
+interface UseProteinCountUpProps extends Omit<CountUpProps, 'end'> {
+  end?: number;
 }
 
 type InputContextProps = {
@@ -24,10 +30,13 @@ export const InputContext = createContext<InputContextProps>({
   setGramTotal: () => {},
 });
 
-export default function MainFunction() {
+export default function MainFunction({ end, ...options }: UseProteinCountUpProps) {
   const [inputValues, setInputValues] = useState<InputProps[]>([]);
   const [gramTotal, setGramTotal] = useState<number>(120);
-
+  const { countUpRef, update } = useProteinCount({
+    end: gramTotal,
+    ...options,
+  });
   useEffect(() => {
     const historyItem = localStorage.getItem('inputHistory');
     if (historyItem) {
@@ -40,12 +49,19 @@ export default function MainFunction() {
     const historyGram = Number(localStorage.getItem('gramTotal'));
     if (historyGram) {
       setGramTotal(historyGram);
+      update(gramTotal);
       console.log('gramTotal', gramTotal);
     }
   }, [gramTotal]);
   return (
     <VStack mx={3}>
       <Heading>1日の摂取プロテイン目安</Heading>
+      <Flex justifyContent={'center'} alignItems={'center'}>
+        <Box fontSize={100} pr={3} ref={countUpRef} />
+        <Text fontSize={60} pt={2}>
+          g
+        </Text>
+      </Flex>
       <InputContext.Provider value={{ inputValues, gramTotal, setInputValues, setGramTotal }}>
         <InputForm initialValue={0} />
         <Heading as='h3' size='lg' py={4}>


### PR DESCRIPTION
# プロテイン摂取履歴を削除時に摂取カウントを加算する
画像①箇所の摂取履歴をクリックした時に②箇所のプロテインカウントを摂取履歴のグラム数分加算する処理を実装
<img width="758" alt="スクリーンショット 2023-05-13 12 45 17" src="https://github.com/YU01BLC/ProteinManager/assets/60055697/4f9cac2d-5eef-441d-8942-f1c9b2d87671">

## 変更点
- src/component/inputForm.tsx
  - プロテインカウントを表示する箇所を削除致しました。
    - 関連する処理も同様に削除致しました。

- src/component/inputHistory.tsx
  - 摂取履歴箇所の「削除」ボタンを押下した時の処理を追加致しました。
    - 摂取グラム数をローカルストレージに保存する処理を実装致しました。
    - 摂取履歴を削除する時に摂取グラム数を加算するために親コンポーネント側のstateを更新致しました。

- src/page/mainFunction.tsx
  - `inputForm.tsx`側で実装していたプロテインカウントの処理を当コンポーネントに再実装致しました。

