### PR TITLE
プロテインメーター加減処理追加

### DIFF
--- a/src/component/inputForm.tsx
+++ b/src/component/inputForm.tsx
@@ -12,7 +12,6 @@ import {
   NumberDecrementStepper,
 } from '@chakra-ui/react';
 import { useState, useContext } from 'react';
-import { CountUpProps } from 'react-countup';
 import RegisterButton from './uiParts/registerButton';
 import { InputContext } from '../page/mainFunction';
 
@@ -25,7 +24,7 @@ export default function InputForm({ initialValue, onChange }: FormProps) {
   const [name, setName] = useState<string>('');
   const [gram, setGram] = useState<number>(initialValue);
   const [invalidFlg, setInvalidFlg] = useState<boolean>(false);
-  const { inputValues, gramTotal, setInputValues, setGramTotal } = useContext(InputContext);
+  const { inputValues, gramTotal, meterCount, setInputValues, setGramTotal, setMeterCount } = useContext(InputContext);
 
   const handleSubmit = (): void => {
     if (name === '' || gram === 0) {
@@ -42,6 +41,10 @@ export default function InputForm({ initialValue, onChange }: FormProps) {
     const result: number = gramTotal - gram;
     setGramTotal(result);
     setInputValues(newInputValues);
+    setMeterCount(meterCount + gram);
+    if (meterCount + gram > 100) {
+      setMeterCount(100);
+    }
     localStorage.setItem('inputHistory', JSON.stringify(newInputValues));
     localStorage.setItem('gramTotal', result.toString());
     setName('');

--- a/src/component/inputHistory.tsx
+++ b/src/component/inputHistory.tsx
@@ -3,14 +3,18 @@ import { useContext } from 'react';
 import { InputContext } from '../page/mainFunction';
 
 export default function InputHistory() {
-  const { inputValues, gramTotal, setInputValues, setGramTotal } = useContext(InputContext);
+  const { inputValues, gramTotal, meterCount, setInputValues, setGramTotal, setMeterCount } = useContext(InputContext);
 
   const handleDelete = (index: number) => {
     const newInputValues = [...inputValues];
     newInputValues.splice(index, 1);
     setInputValues(newInputValues);
-    const result: number = gramTotal + inputValues[0].gram;
+    const result: number = gramTotal + inputValues[index].gram;
     setGramTotal(result);
+    setMeterCount(meterCount - inputValues[index].gram);
+    if (meterCount - inputValues[index].gram < 0) {
+      setMeterCount(0);
+    }
     localStorage.setItem('gramTotal', result.toString());
     localStorage.setItem('inputHistory', JSON.stringify(newInputValues));
   };

--- a/src/component/proteinMeter.tsx
+++ b/src/component/proteinMeter.tsx
@@ -1,12 +1,16 @@
+import { useContext } from 'react';
 import { Box, Flex } from '@chakra-ui/react';
 import BatteryGauge from 'react-battery-gauge';
+import { InputContext } from '../page/mainFunction';
 
 export default function ProteinMeter() {
+  const { meterCount } = useContext(InputContext);
+
   return (
     <Box>
       <Flex justifyContent={'center'}>
         <BatteryGauge
-          value={80}
+          value={meterCount}
           size={500}
           animated={true}
           aspectRatio={0.23}
@@ -26,3 +30,5 @@ export default function ProteinMeter() {
     </Box>
   );
 }
+
+// 1gあたり7.5分が消化時間目安

--- a/src/page/mainFunction.tsx
+++ b/src/page/mainFunction.tsx
@@ -19,30 +19,38 @@ interface UseProteinCountUpProps extends Omit<CountUpProps, 'end'> {
 type InputContextProps = {
   inputValues: InputProps[];
   gramTotal: number;
+  meterCount: number;
   setGramTotal: React.Dispatch<React.SetStateAction<number>>;
+  setMeterCount: React.Dispatch<React.SetStateAction<number>>;
   setInputValues: React.Dispatch<React.SetStateAction<InputProps[]>>;
 };
 
 export const InputContext = createContext<InputContextProps>({
   inputValues: [],
   gramTotal: 0,
+  meterCount: 0,
   setInputValues: () => {},
   setGramTotal: () => {},
+  setMeterCount: () => {},
 });
 
 export default function MainFunction({ end, ...options }: UseProteinCountUpProps) {
+  const initialNumber = 120;
   const [inputValues, setInputValues] = useState<InputProps[]>([]);
-  const [gramTotal, setGramTotal] = useState<number>(120);
+  const [gramTotal, setGramTotal] = useState<number>(initialNumber);
+  const [meterCount, setMeterCount] = useState<number>(0);
   const { countUpRef, update } = useProteinCount({
     end: gramTotal,
     ...options,
   });
   useEffect(() => {
     const historyItem = localStorage.getItem('inputHistory');
+    const historyGram = Number(localStorage.getItem('gramTotal'));
     if (historyItem) {
       setInputValues(JSON.parse(historyItem) as InputProps[]);
-      console.log('storageItem', historyItem);
+      setMeterCount(initialNumber - historyGram);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
@@ -50,9 +58,12 @@ export default function MainFunction({ end, ...options }: UseProteinCountUpProps
     if (historyGram) {
       setGramTotal(historyGram);
       update(gramTotal);
-      console.log('gramTotal', gramTotal);
     }
-  }, [gramTotal, update]);
+    if (gramTotal === 0) {
+      update(0);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [gramTotal]);
   return (
     <VStack mx={3}>
       <Heading>1日の摂取プロテイン目安</Heading>
@@ -62,7 +73,9 @@ export default function MainFunction({ end, ...options }: UseProteinCountUpProps
           g
         </Text>
       </Flex>
-      <InputContext.Provider value={{ inputValues, gramTotal, setInputValues, setGramTotal }}>
+      <InputContext.Provider
+        value={{ inputValues, gramTotal, meterCount, setInputValues, setGramTotal, setMeterCount }}
+      >
         <InputForm initialValue={0} />
         <Heading as='h3' size='lg' py={4}>
           体内プロテイン残量


### PR DESCRIPTION
# プロテインメーター加減処理追加
プロテイン摂取タイミングと摂取履歴削除タイミングでプロテインメーターを加減するよう実装

## 変更点
- src/component/inputForm.tsx
  - プロテインメーターに渡すstateの上限値が100になるよう実装致しました。

- src/component/inputHistory.tsx
  - プロテインメーターに渡すstateの下限値が0になるよう実装致しました。

- src/component/proteinMeter.tsx
  - `meterCount`の更新に伴いメーターが加減されるよう実装致しました。

- src/page/mainFunction.tsx
  - プロテインメーターに渡すstateを実装致しました。


